### PR TITLE
Add workflow to enforce delete branch on merge setting

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,0 +1,30 @@
+name: Enforce Repository Settings
+
+on:
+  schedule:
+    # Runs daily at 9 AM UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  enforce-delete-branch-on-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable delete branch on merge for all repos
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+        run: |
+          echo "Fetching all repositories..."
+          repos=$(gh repo list prodigal-tech --limit 500 --json name,deleteBranchOnMerge)
+
+          # Count repos that need updating
+          count=$(echo "$repos" | jq '[.[] | select(.deleteBranchOnMerge == false)] | length')
+          echo "Found $count repositories that need updating"
+
+          # Update repos that don't have the setting enabled
+          echo "$repos" | jq -r '.[] | select(.deleteBranchOnMerge == false) | .name' | while read repo; do
+            echo "Enabling delete branch on merge for: $repo"
+            gh repo edit "prodigal-tech/$repo" --delete-branch-on-merge
+          done
+
+          echo "Done! Updated $count repositories."


### PR DESCRIPTION
Runs daily at 9 AM UTC and enables 'delete branch on merge' for all repos that don't have it enabled. Can also be triggered manually.

Requires ORG_ADMIN_TOKEN secret with repo admin permissions.

## Prodigal Technologies Change Request

**Description**: 
<!-- [REQUIRED] Provide a detailed description of what this change does -->

**Justification**: 
<!-- [REQUIRED] Business reason for the change -->

**Type of Change**: 
<!-- [REQUIRED]
"Emergency": Emergency change is a high-priority, high-risk change that must be implemented immediately to address a critical incident or situation 
OR 
"Standard": Standard change is a pre-authorized, low-risk change that follows a predefined procedure.
-->

**Impact Assessment**: 
<!-- [REQUIRED] List all systems/services/customers affected by this change -->

**Rollback Procedure**: Revert to previous release version/commit
<!-- [REQUIRED] Step-by-step instructions to roll back this change if needed -->

**Asana Task Link**: 
<!-- [OPTIONAL] Link to the corresponding Asana task -->

## Testing & Security

**Testing Performed**:
<!-- [REQUIRED] Describe testing that was done (unit, integration, QA, etc.) -->

**Security Considerations(if-any)**: 
<!-- [OPTIONAL] Address any security implications of this change, reference OWASP Top 10 if applicable -->

## Checklist
<!-- [REQUIRED] According to Prodigal policy -->
- [ ] Peer code review completed
- [ ] Dev/QA testing performed
- [ ] Documentation updated - if applicable (Asana, code comments, Notion, git comments)
